### PR TITLE
Fixes, functionality to main gui

### DIFF
--- a/config/meta.ini
+++ b/config/meta.ini
@@ -1,2 +1,2 @@
 [General]
-activeUserProfile=test
+activeUserProfile=Default

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiController.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiController.ahk
@@ -156,7 +156,7 @@ Class ExtraKeyboardsAppGuiController{
             msgbox("Could not delete hotkey. " . e.Message)
         }
         this.view.UpdateHotkeys()
-
+        this.view.ChangeConfigurationButtonsStatus(1)
         this.MainScript.RunLogicalStartup()
     }
 

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiController.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiController.ahk
@@ -155,6 +155,8 @@ Class ExtraKeyboardsAppGuiController{
             this.MainScript.SetHotkeysForAllLayers(false)
             msgbox("Could not delete hotkey. " . e.Message)
         }
+        this.view.UpdateHotkeys()
+
         this.MainScript.RunLogicalStartup()
     }
 

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
@@ -61,12 +61,12 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         this.hotkeysListView.CreateListView(this, "r20 w600 x+10 -multi" , ["KeyCombo","Action"])
         
 
-        this.ButtonForAddingInfo := this.Add("Button", "", "Add")
+        this.ButtonForAddingInfo := this.Add("Button", "Default", "Add")
         this.ButtonForAddingInfo.OnEvent("Click", (*) => this.controller.DoAddOrEditHotkey())
-
         this.ButtonForAddingInfo.Opt("Hidden1")
 
-        this.ButtonForEditingInfo := this.Add("Button", "Yp", "Edit")
+        this.ButtonForEditingInfo := this.Add("Button", " Yp", "Edit")
+        this.ButtonForEditingInfo.OnEvent("Click", (*) => this.controller.DoAddOrEditHotkey(this.hotkeysListView.GetSelectionText()))
         this.ButtonForEditingInfo.Opt("Hidden1")
 
         this.ButtonForDeletingInfo := this.Add("Button", "Yp", "Delete")
@@ -104,12 +104,16 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
     }
 
     EnableConfigurationButtons(){
+        this.ButtonForAddingInfo.Opt("-Default")
         this.ButtonForEditingInfo.Enabled := true
+        this.ButtonForEditingInfo.Opt("+Default")
         this.ButtonForDeletingInfo.Enabled := true
     }
 
     DisableConfigurationButtons(){
+        this.ButtonForAddingInfo.Opt("+Default")
         this.ButtonForEditingInfo.Enabled := false
+        this.ButtonForEditingInfo.Opt("-Default")
         this.ButtonForDeletingInfo.Enabled := false
     }
 

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
@@ -110,7 +110,12 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
             this.DisableConfigurationButtons()
         }
         else{
-            this.EnableConfigurationButtons()
+            if (this.hotkeysListView.GetCount() = 0){
+                this.DisableConfigurationButtons()
+            }
+            else{
+                this.EnableConfigurationButtons()
+            }
         }
     }
 

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
@@ -61,7 +61,7 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         this.hotkeysListView.CreateListView(this, "r20 w600 x+10 -multi" , ["KeyCombo","Action"])
         
 
-        this.ButtonForAddingInfo := this.Add("Button", "Default", "Add")
+        this.ButtonForAddingInfo := this.Add("Button", "", "Add")
         this.ButtonForAddingInfo.OnEvent("Click", (*) => this.controller.DoAddOrEditHotkey())
         this.ButtonForAddingInfo.Opt("Hidden1")
 
@@ -94,6 +94,9 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         }
     }
 
+    ; If the focues row is 0 (a row without values) the edit and delete buttons are disabled,
+    ; Since they should only be active when a row with values is selected.
+    ; If the row is not 0, the edit and delete buttons are enabled.
     ChangeConfigurationButtonsStatus(rowFocused){
         if (rowFocused = 0){
             this.DisableConfigurationButtons()
@@ -103,6 +106,8 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         }
     }
 
+    ; Enables the edit/delete button, and makes the edit button the default button.
+    ; Meaning that it is pressed when the user presses enter
     EnableConfigurationButtons(){
         this.ButtonForAddingInfo.Opt("-Default")
         this.ButtonForEditingInfo.Enabled := true
@@ -110,6 +115,8 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         this.ButtonForDeletingInfo.Enabled := true
     }
 
+    ; Disables the edit/delete button, and makes the add button the default button.
+    ; Meaning that it is pressed when the user presses enter
     DisableConfigurationButtons(){
         this.ButtonForAddingInfo.Opt("+Default")
         this.ButtonForEditingInfo.Enabled := false

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
@@ -6,6 +6,8 @@
 #Include <UserInterface\Main\util\TreeViewMaker>
 #Include <UserInterface\Main\util\ListViewMaker>
 
+#Include <Util\HotkeyFormatConverter>
+
 #Include <Util\MetaInfo\MetaInfoStorage\KeyboardLayouts\KeyboardsInfo\Hotkeys\entity\HotKeyInfo>
 
 
@@ -79,6 +81,8 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         this.ButtonForEditingInfo.Opt("Hidden1")
 
         this.ButtonForDeletingInfo := this.Add("Button", "Yp", "Delete")
+        this.ButtonForDeletingInfo.OnEvent("Click", (*) => this.controller.DeleteHotkey(HotkeyFormatConverter.convertFromFriendlyName(this.hotkeysListView.GetSelectionText())))
+
         this.ButtonForDeletingInfo.Opt("Hidden1")
 
     }

--- a/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
+++ b/src/Main/Lib/UserInterface/ExtraKeyboardsAppGuiView.ahk
@@ -60,7 +60,16 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
         this.hotkeysListView := ListViewMaker()
         this.hotkeysListView.CreateListView(this, "r20 w600 x+10 -multi" , ["KeyCombo","Action"])
         
+        this.CreateConfigurationButtons()
 
+        this.hotkeysListView.AddEventAction("ItemSelect", (listView, rowSelected, ColumnSelected) => this.ChangeConfigurationButtonsStatus(rowSelected))
+        keyboardLayoutChanger.AddEventAction("ItemSelect", (*) => this.controller.DoLayerSelected(keyboardLayoutChanger.GetSelectionText()))
+        this.hotkeysListView.AddEventAction("DoubleClick", (listView, rowClicked) => this.controller.DoAddOrEditHotkey(listView.GetText(rowClicked, 1)))
+
+    }
+
+    CreateConfigurationButtons(){
+        
         this.ButtonForAddingInfo := this.Add("Button", "", "Add")
         this.ButtonForAddingInfo.OnEvent("Click", (*) => this.controller.DoAddOrEditHotkey())
         this.ButtonForAddingInfo.Opt("Hidden1")
@@ -71,11 +80,6 @@ Class ExtraKeyboardsAppGuiView extends DomainSpecificGui{
 
         this.ButtonForDeletingInfo := this.Add("Button", "Yp", "Delete")
         this.ButtonForDeletingInfo.Opt("Hidden1")
-
-
-        this.hotkeysListView.AddEventAction("ItemSelect", (listView, rowSelected, ColumnSelected) => this.ChangeConfigurationButtonsStatus(rowSelected))
-        keyboardLayoutChanger.AddEventAction("ItemSelect", (*) => this.controller.DoLayerSelected(keyboardLayoutChanger.GetSelectionText()))
-        this.hotkeysListView.AddEventAction("DoubleClick", (listView, rowClicked) => this.controller.DoAddOrEditHotkey(listView.GetText(rowClicked, 1)))
 
     }
 

--- a/src/Main/Lib/UserInterface/Main/ProfileEditing/ProfileRegionController.ahk
+++ b/src/Main/Lib/UserInterface/Main/ProfileEditing/ProfileRegionController.ahk
@@ -138,6 +138,8 @@ class ProfileRegionController{
     }
 
     ; TODO this methods is way too long..
+    ; TODO make it suppport multi select
+    ; TODO make it possible to drag files onto gui to add profiles..
     doImportProfile(){
         selectedFilePath := FileSelect("D", , "Choose a location to save profile",)
         ; Guard condition

--- a/src/Main/Lib/UserInterface/Main/ProfileEditing/ProfileRegionView.ahk
+++ b/src/Main/Lib/UserInterface/Main/ProfileEditing/ProfileRegionView.ahk
@@ -26,10 +26,10 @@ class ProfileRegionView{
         
         this.profilesDropDownMenu.OnEvent("Change", (*) => this.NotifyListenersProfileChanged(this.profilesDropDownMenu.Text))
 
-        this.editProfilesButton := guiObject.Add("Button", "Default w80 ym+1", "&Edit profiles")
-        addProfileButton := guiObject.Add("Button", "Default w80 ym+1", "&Add profile")
-        importProfileButton := guiObject.Add("Button", "Default w80 ym+1", "&Import profile")
-        exportProfileButton := guiObject.Add("Button", "Default w80 ym+1", "E&xport profile")
+        this.editProfilesButton := guiObject.Add("Button", "w80 ym+1", "&Edit profiles")
+        addProfileButton := guiObject.Add("Button", "w80 ym+1", "&Add profile")
+        importProfileButton := guiObject.Add("Button", "w80 ym+1", "&Import profile")
+        exportProfileButton := guiObject.Add("Button", "w80 ym+1", "E&xport profile")
         
 
         this.editProfilesButton.OnEvent("Click", (*) =>  ObjBindMethod(controller, "doOpenEditProfileView")())

--- a/src/Main/Lib/UserInterface/Main/util/ListViewMaker.ahk
+++ b/src/Main/Lib/UserInterface/Main/util/ListViewMaker.ahk
@@ -1,6 +1,7 @@
 #Requires AutoHotkey v2.0
 
 ; TODO listviewmaker and treeviewmaker could inherit from a class...
+; TODO atleas inheritance from list view gui control...
 class ListViewMaker{
 
     listView := ""
@@ -94,5 +95,9 @@ class ListViewMaker{
             selectedText := this.listView.GetText(this.listView.GetNext( , "Focused"), columnNumber)
         }
         return selectedText
+    }
+
+    GetCount(){
+        return this.listView.GetCount()
     }
 }


### PR DESCRIPTION
* When pressing enter on the main gui, the add/edit/whatever profile buttons will no longer be clicked.
* Added functionality to the "Edit" button used to edit hotkeys
* Added functionality to the "Delete" button used to delete hotkeys
* Fixed issue with "Add" button being clicked when it should not be clickable.
* Fixed issue with edit/delete buttons not being disabled when no hotkeys can be edited/deleted.
* Refactoring